### PR TITLE
Added alternative fonts.

### DIFF
--- a/css/evo-doc-content.css
+++ b/css/evo-doc-content.css
@@ -8,7 +8,7 @@
 
 .evo-content {
 	margin: 0em 0em;
-	font-family: 'Proxima Nova Regular';
+	font-family: 'Proxima Nova Regular', Helvetica, Arial;
 	text-decoration: none;
 }
 


### PR DESCRIPTION
In case the custom Proxima Nova font can't be loaded (like when the documentation is viewed locally in IE 10, see https://github.com/evothings/evothings-doc/issues/35), one of the alternative fonts will be used instead.
